### PR TITLE
Remove -stdlib=libc++ for compatiblity with OS X 10.10

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
         }],
         ["OS=='mac'", {
           "xcode_settings": {
-            "OTHER_CPLUSPLUSFLAGS" : ["-std=c++11","-stdlib=libc++","-mmacosx-version-min=10.7"],
+            "OTHER_CPLUSPLUSFLAGS" : ["-std=c++11","-mmacosx-version-min=10.7"],
             "OTHER_LDFLAGS": ["-std=c++11"],
           }
         }],


### PR DESCRIPTION
This change makes the project build for OS X 10.10 where it previously failed with `c++: error: unrecognized command line option '-stdlib=libc++'`.