### PR TITLE
upgrade nan 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "node-lmdb",
   "description": "Node binding for LMDB, the Lightning Memory-Mapped Database",
   "author": "Timur Kristóf <venemo@fedoraproject.org>",
-  "contributors": ["Erich Ocean <erich@xygroup.co>"],
+  "contributors": [
+    "Erich Ocean <erich@xygroup.co>"
+  ],
   "license": "MIT",
   "keywords": [
     "lmdb",
@@ -16,6 +18,6 @@
   "main": "./build/Release/node-lmdb",
   "gypfile": true,
   "dependencies": {
-    "nan": "^2.0.9"
+    "nan": "2.2.0"
   }
 }

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -96,7 +96,7 @@ Nan::NAN_METHOD_RETURN_TYPE CursorWrap::getCommon(
     void (*setKey)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
     void (*setData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
     void (*freeData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
-    Handle<Value> (*convertFunc)(MDB_val &data)
+    Local<Value> (*convertFunc)(MDB_val &data)
 ) {
     Nan::HandleScope scope;
 
@@ -124,7 +124,7 @@ Nan::NAN_METHOD_RETURN_TYPE CursorWrap::getCommon(
         return Nan::ThrowError(mdb_strerror(rc));
     }
 
-    Handle<Value> keyHandle = Nan::Undefined();
+    Local<Value> keyHandle = Nan::Undefined();
     if (cw->key.mv_size) {
         keyHandle = keyToHandle(cw->key, cw->keyIsUint32);
     }
@@ -132,8 +132,8 @@ Nan::NAN_METHOD_RETURN_TYPE CursorWrap::getCommon(
     if (convertFunc && al > 0 && info[al - 1]->IsFunction()) {
         // In this case, we expect the key/data pair to be correctly filled
         const unsigned argc = 2;
-        Handle<Value> argv[argc] = { keyHandle, convertFunc(cw->data) };
-        Nan::Callback *callback = new Nan::Callback(Handle<Function>::Cast(info[info.Length() - 1]));
+        Local<Value> argv[argc] = { keyHandle, convertFunc(cw->data) };
+        Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[info.Length() - 1]));
         callback->Call(argc, argv);
         delete callback;
     }

--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -146,7 +146,7 @@ NAN_METHOD(DbiWrap::drop) {
     // Check if the database should be deleted
     if (info.Length() == 2 && info[1]->IsObject()) {
         Handle<Object> options = info[1]->ToObject();
-        Handle<Value> opt = options->Get(Nan::New<String>("justFreePages").ToLocalChecked());
+        Local<Value> opt = options->Get(Nan::New<String>("justFreePages").ToLocalChecked());
         del = opt->IsBoolean() ? !(opt->BooleanValue()) : 1;
     }
 

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -71,7 +71,7 @@ NAN_METHOD(EnvWrap::ctor) {
 template<class T>
 int applyUint32Setting(int (*f)(MDB_env *, T), MDB_env* e, Local<Object> options, T dflt, const char* keyName) {
     int rc;
-    const Handle<Value> value = options->Get(Nan::New<String>(keyName).ToLocalChecked());
+    const Local<Value> value = options->Get(Nan::New<String>(keyName).ToLocalChecked());
     if (value->IsUint32()) {
         rc = f(e, value->Uint32Value());
     }
@@ -106,7 +106,7 @@ NAN_METHOD(EnvWrap::open) {
     }
 
     // Parse the mapSize option
-    Handle<Value> mapSizeOption = options->Get(Nan::New<String>("mapSize").ToLocalChecked());
+    Local<Value> mapSizeOption = options->Get(Nan::New<String>("mapSize").ToLocalChecked());
     if (mapSizeOption->IsNumber()) {
         double mapSizeDouble = mapSizeOption->NumberValue();
         size_t mapSizeSizeT = (size_t) mapSizeDouble;
@@ -166,7 +166,7 @@ NAN_METHOD(EnvWrap::beginTxn) {
 
     const unsigned argc = 2;
 
-    Handle<Value> argv[argc] = { info.This(), info[0] };
+    Local<Value> argv[argc] = { info.This(), info[0] };
     Local<Object> instance = Nan::New(txnCtor)->NewInstance(argc, argv);
 
     info.GetReturnValue().Set(instance);
@@ -176,7 +176,7 @@ NAN_METHOD(EnvWrap::openDbi) {
     Nan::HandleScope scope;
 
     const unsigned argc = 2;
-    Handle<Value> argv[argc] = { info.This(), info[0] };
+    Local<Value> argv[argc] = { info.This(), info[0] };
     Local<Object> instance = Nan::New(dbiCtor)->NewInstance(argc, argv);
 
     info.GetReturnValue().Set(instance);
@@ -191,7 +191,7 @@ NAN_METHOD(EnvWrap::sync) {
         return Nan::ThrowError("The environment is already closed.");
     }
 
-    Handle<Function> callback = Handle<Function>::Cast(info[0]);
+    Local<Function> callback = info[0].As<Function>();
 
     EnvSyncData *d = new EnvSyncData;
     d->request.data = d;
@@ -209,7 +209,7 @@ NAN_METHOD(EnvWrap::sync) {
         // Executed after the sync is finished
         EnvSyncData *d = static_cast<EnvSyncData*>(request->data);
         const unsigned argc = 1;
-        Handle<Value> argv[argc];
+        Local<Value> argv[argc];
 
         if (d->rc == 0) {
             argv[0] = Nan::Null();

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -39,13 +39,13 @@ void setupExportMisc(Handle<Object> exports) {
 }
 
 void setFlagFromValue(int *flags, int flag, const char *name, bool defaultValue, Local<Object> options) {
-    Handle<Value> opt = options->Get(Nan::New<String>(name).ToLocalChecked());
+    Local<Value> opt = options->Get(Nan::New<String>(name).ToLocalChecked());
     if (opt->IsBoolean() ? opt->BooleanValue() : defaultValue) {
         *flags |= flag;
     }
 }
 
-argtokey_callback_t argToKey(const Handle<Value> &val, MDB_val &key, bool keyIsUint32) {
+argtokey_callback_t argToKey(const Local<Value> &val, MDB_val &key, bool keyIsUint32) {
     // Check key type
     if (keyIsUint32 && !val->IsUint32()) {
         Nan::ThrowError("Invalid key. keyIsUint32 specified on the database, but the given key was not an unsigned 32-bit integer");
@@ -78,7 +78,7 @@ argtokey_callback_t argToKey(const Handle<Value> &val, MDB_val &key, bool keyIsU
     return nullptr;
 }
 
-Handle<Value> keyToHandle(MDB_val &key, bool keyIsUint32) {
+Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32) {
     if (keyIsUint32) {
         return Nan::New<Integer>(*((uint32_t*)key.mv_data));
     }
@@ -87,14 +87,14 @@ Handle<Value> keyToHandle(MDB_val &key, bool keyIsUint32) {
     }
 }
 
-Handle<Value> valToString(MDB_val &data) {
+Local<Value> valToString(MDB_val &data) {
     auto resource = new CustomExternalStringResource(&data);
-    auto str = String::NewExternalTwoByte(Isolate::GetCurrent(), resource);
+    auto str = Nan::New<v8::String>(resource);
 
     return str.ToLocalChecked();
 }
 
-Handle<Value> valToBinary(MDB_val &data) {
+Local<Value> valToBinary(MDB_val &data) {
     // FIXME: It'd be better not to copy buffers, but I'm not sure
     // about the ownership semantics of MDB_val, so let' be safe.
     return Nan::CopyBuffer(
@@ -103,11 +103,11 @@ Handle<Value> valToBinary(MDB_val &data) {
     ).ToLocalChecked();
 }
 
-Handle<Value> valToNumber(MDB_val &data) {
+Local<Value> valToNumber(MDB_val &data) {
     return Nan::New<Number>(*((double*)data.mv_data));
 }
 
-Handle<Value> valToBoolean(MDB_val &data) {
+Local<Value> valToBoolean(MDB_val &data) {
     return Nan::New<Boolean>(*((bool*)data.mv_data));
 }
 
@@ -120,7 +120,7 @@ void consoleLog(const char *msg) {
     Nan::RunScript(script);
 }
 
-void consoleLog(Handle<Value> val) {
+void consoleLog(Local<Value> val) {
     Local<String> str = Nan::New<String>("console.log('").ToLocalChecked();
     str = String::Concat(str, val->ToString());
     str = String::Concat(str, Nan::New<String>("');").ToLocalChecked());

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -42,16 +42,16 @@ void setupExportMisc(Handle<Object> exports);
 // Helper callback
 typedef void (*argtokey_callback_t)(MDB_val &key);
 
-void consoleLog(Handle<Value> val);
+void consoleLog(Local<Value> val);
 void consoleLog(const char *msg);
 void consoleLogN(int n);
 void setFlagFromValue(int *flags, int flag, const char *name, bool defaultValue, Local<Object> options);
-argtokey_callback_t argToKey(const Handle<Value> &val, MDB_val &key, bool keyIsUint32);
-Handle<Value> keyToHandle(MDB_val &key, bool keyIsUint32);
-Handle<Value> valToString(MDB_val &data);
-Handle<Value> valToBinary(MDB_val &data);
-Handle<Value> valToNumber(MDB_val &data);
-Handle<Value> valToBoolean(MDB_val &data);
+argtokey_callback_t argToKey(const Local<Value> &val, MDB_val &key, bool keyIsUint32);
+Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32);
+Local<Value> valToString(MDB_val &data);
+Local<Value> valToBinary(MDB_val &data);
+Local<Value> valToNumber(MDB_val &data);
+Local<Value> valToBoolean(MDB_val &data);
 
 /*
     `Env`
@@ -178,7 +178,7 @@ public:
     static NAN_METHOD(ctor);
 
     // Helper for all the get methods (not exposed)
-    static Nan::NAN_METHOD_RETURN_TYPE getCommon(Nan::NAN_METHOD_ARGS_TYPE info, Handle<Value> (*successFunc)(MDB_val&));
+    static Nan::NAN_METHOD_RETURN_TYPE getCommon(Nan::NAN_METHOD_ARGS_TYPE info, Local<Value> (*successFunc)(MDB_val&));
 
     // Helper for all the put methods (not exposed)
     static Nan::NAN_METHOD_RETURN_TYPE putCommon(Nan::NAN_METHOD_ARGS_TYPE info, void (*fillFunc)(Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&), void (*freeFunc)(MDB_val&));
@@ -413,7 +413,7 @@ public:
         void (*setKey)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
         void (*setData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
         void (*freeData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
-        Handle<Value> (*convertFunc)(MDB_val &data));
+        Local<Value> (*convertFunc)(MDB_val &data));
 
     // Helper method for getters (not exposed)
     static Nan::NAN_METHOD_RETURN_TYPE getCommon(Nan::NAN_METHOD_ARGS_TYPE info, MDB_cursor_op op);

--- a/src/txn.cpp
+++ b/src/txn.cpp
@@ -135,7 +135,7 @@ NAN_METHOD(TxnWrap::renew) {
     return;
 }
 
-Nan::NAN_METHOD_RETURN_TYPE TxnWrap::getCommon(Nan::NAN_METHOD_ARGS_TYPE info, Handle<Value> (*successFunc)(MDB_val&)) {
+Nan::NAN_METHOD_RETURN_TYPE TxnWrap::getCommon(Nan::NAN_METHOD_ARGS_TYPE info, Local<Value> (*successFunc)(MDB_val&)) {
     Nan::HandleScope scope;
 
     TxnWrap *tw = Nan::ObjectWrap::Unwrap<TxnWrap>(info.This());


### PR DESCRIPTION
I pulled down master and couldn't get it to build. It seemed there were some issues with the version of nan (flappy version ranges) and I'm also targeting v0.10.

I had to change 2 things to make this work, first of all I found that I needed to explicitly use `v8::Local` as types would not implicitly cast from `v8::Handle` to `v8::Local` (which makes sense).

Also to stringify an external string resource I had to use the Nan method to navigate the various differences in v8.

I compiled/tested the changes with node 0.10, node 0.12 and node 4 at their latest respective versions.

If you think that using Local/Persisted explicitly instead of Handle is going to be a problem I'd like to understand.