### PR TITLE
Auto value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Here are the main highlights of LMDB, for more, visit http://symas.com/mdb :)
 
 * Tested and works on Linux (author uses Fedora 20)
 * Tested and works on Mac OS X - see https://github.com/Venemo/node-lmdb/issues/3
-* **Not yet tested** on Windows - see https://github.com/Venemo/node-lmdb/issues/2
+* Tested and works on Windows (using Windows 10 with MSVS 2015 - see https://github.com/Venemo/node-lmdb/issues/2
+
 
 ### License info
 
@@ -86,10 +87,9 @@ dbi.close();
 
 The basic unit of work in LMDB is a transaction, which is called `Txn` for short. Here is how you operate with your data.
 Every piece of data in LMDB is referred to by a **key**.
-You can use the methods `getString()`, `getBinary()`, `getNumber()` and `getBoolean()` to retrieve something,
-`putString()`, `putBinary()`, `putNumber()` and `putBoolean()` to store something and `del()` to delete something.
+You can use the methods `getString()`, `getBinary()`, `getNumber()`, `getBoolean()` and `get` to retrieve something,
+`putString()`, `putBinary()`, `putNumber()`, `putBoolean()` and `put` to store something and `del()` to delete something.
 
-Currently **only string, binary, number and boolean values are supported**, use `JSON.stringify` and `JSON.parse` for complex data structures.
 Because of the nature of LMDB, the data returned by `txn.getString()` and `txn.getBinary()` is only valid until the next `put` operation or the end of the transaction.
 If you need to use the data *later*, you will have to copy it for yourself.
 
@@ -110,6 +110,29 @@ else {
 
 txn.putString(dbi, 2, "Yes, it's this simple!");
 txn.commit();
+```
+
+#### Auto data types
+
+`get` and `put` methods supports the following data types:
+
+- Number
+- Boolean
+- String
+- Buffer
+- Object
+- Array
+
+Putting `null` as value is equal to deleting a record.
+
+```
+txn.put(dbi, "key1", 42);
+txn.put(dbi, "key2", true);
+txn.put(dbi, "key3", "Hello world!");
+txn.put(dbi, "key4", {a: 1, b: "abcde"});
+txn.put(dbi, "key5", [1, 2, 3, 4, 5]);
+txn.put(dbi, "key6", Buffer.from([1, 2, 3]));
+txn.put(dbi, "key7", null); // is equal to txn.del(dbi, "key7");
 ```
 
 ### Basic concepts
@@ -141,6 +164,7 @@ The basic examples we currently have:
 * `example5-dupsort.js` - shows how to use a `dupSort` database with cursors
 * `example6-asyncio.js` - shows how to use the fastest (but also most dangerous) way for async IO
 * `example7-largedb.js` - shows how to work with an insanely large database
+* `example10-auto-datatypes.js` - shows how to work with auto data types
 
 Advanced examples:
 
@@ -149,7 +173,6 @@ Advanced examples:
 
 ### Limitations of node-lmdb
 
-* **Only string, binary, number and boolean values are supported.** If you want to store complex data structures, use `JSON.stringify` before putting it into the database and `JSON.parse` when you retrieve the data.
 * **Only string and unsigned integer keys are supported.** Default is string, specify `keyIsUint32: true` to `openDbi` for unsigned integer. It would make the API too complicated to support more data types for keys.
 * Because of the nature of LMDB, the data returned by `txn.getString()` and `txn.getBinary()` is **only valid until the next `put` operation or the end of the transaction**. If you need to use the data *later*, you will have to copy it for yourself.
 * Fixed address map (called `MDB_FIXEDMAP` in C) features are **not exposed** by this binding because they are highly experimental

--- a/example10-auto-datatypes.js
+++ b/example10-auto-datatypes.js
@@ -88,6 +88,21 @@ try {
     console.log(e.message);
 }
 
+// Example for getting/putting/deleting array data
+// ----------
+try {
+    var arrayData = txn.get(dbi, "key7");
+    // Print the boolean
+    console.log("array data: ", arrayData, typeof arrayData);
+    // Toggle the value
+    if (arrayData === null)
+        txn.put(dbi, "key7", [1, 2, 3, 4, 5]);
+    else
+        txn.del(dbi, "key7");
+} catch (e) {
+    console.log(e.message);
+}
+
 console.log("");
 console.log("Run this example again to see the alterations on the database!");
 

--- a/example10-auto-datatypes.js
+++ b/example10-auto-datatypes.js
@@ -1,0 +1,99 @@
+
+var lmdb = require('./build/Release/node-lmdb');
+var env = new lmdb.Env();
+env.open({
+    // Path to the environment
+    path: "./testdata",
+    // Maximum number of databases
+    maxDbs: 10
+});
+var dbi = env.openDbi({
+   name: "mydb2",
+   create: true
+});
+
+// Create transaction
+var txn = env.beginTxn();
+
+// Example for getting/putting/deleting string data
+// ----------
+var stringData = txn.get(dbi, "key1");
+// Print the string
+console.log("string data: ", stringData, typeof stringData);
+// Toggle the value
+if (stringData === null)
+    txn.put(dbi, "key1", "Hello world!");
+else
+    txn.del(dbi, "key1");
+
+// Example for getting/putting/deleting binary data
+// ----------
+var binaryData = txn.get(dbi, "key2");
+// Print the string representation of the binary
+console.log("binary data: ", binaryData, typeof binaryData);
+// Toggle the value
+if (binaryData === null) {
+    //var buffer = new Buffer("Hey my friend");
+    var buffer = Buffer.from([1, 2, 3]);
+    txn.put(dbi, "key2", buffer);
+}
+else {
+    txn.del(dbi, "key2");
+}
+
+
+// Example for getting/putting/deleting number data
+// ----------
+var numberData = txn.get(dbi, "key3");
+// Print the number
+console.log("number data: ", numberData, typeof numberData);
+// Toggle the value
+if (numberData === null)
+    txn.put(dbi, "key3", 42);
+else
+    txn.del(dbi, "key3");
+
+// Example for getting/putting/deleting boolean data
+// ----------
+var booleanData = txn.get(dbi, "key4");
+// Print the boolean
+console.log("boolean data: ", booleanData, typeof booleanData);
+// Toggle the value
+if (booleanData === null)
+    txn.put(dbi, "key4", true);
+else
+    txn.del(dbi, "key4");
+
+// Example for using integer key
+// ----------
+var data = txn.get(dbi, "key5");
+console.log("integer key value: ", data, typeof data);
+if (data === null)
+    txn.put(dbi, "key5", "Hello worllld!");
+else
+    txn.del(dbi, "key5");
+
+// Example for getting/putting/deleting object data
+// ----------
+try {
+    var objectData = txn.get(dbi, "key6");
+    // Print the boolean
+    console.log("object data: ", objectData, typeof objectData);
+    // Toggle the value
+    if (objectData === null)
+        txn.put(dbi, "key6", {a: 1, b: "abcde"});
+    else
+        txn.del(dbi, "key6");
+} catch (e) {
+    console.log(e.message);
+}
+
+console.log("");
+console.log("Run this example again to see the alterations on the database!");
+
+// Commit transaction
+txn.commit();
+
+dbi.close();
+env.close();
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "version": "0.4.0",
   "main": "./index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/** --recursive"
+    "test": "./node_modules/.bin/mocha test/**/*.js --recursive"
   },
   "gypfile": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "gypfile": true,
   "dependencies": {
-    "nan": "^2.2.0"
+    "nan": "^2.3.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -258,24 +258,24 @@ void CursorWrap::setupExports(Handle<Object> exports) {
     cursorTpl->SetClassName(Nan::New<String>("Cursor").ToLocalChecked());
     cursorTpl->InstanceTemplate()->SetInternalFieldCount(1);
     // CursorWrap: Add functions to the prototype
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("close").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::close)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("getCurrentString").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::getCurrentString)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("getCurrentBinary").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::getCurrentBinary)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("getCurrentNumber").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::getCurrentNumber)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("getCurrentBoolean").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::getCurrentBoolean)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToFirst").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToFirst)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToLast").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToLast)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToNext").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToNext)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToPrev").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToPrev)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToKey").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToKey)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToRange").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToRange)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToFirstDup").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToFirstDup)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToLastDup").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToLastDup)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToNextDup").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToNextDup)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToPrevDup").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToPrevDup)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToDup").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToDup)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("goToDupRange").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::goToDupRange)->GetFunction());
-    cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("del").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::del)->GetFunction());
+    Nan::SetPrototypeMethod(cursorTpl, "close", CursorWrap::close);
+    Nan::SetPrototypeMethod(cursorTpl, "getCurrentString", CursorWrap::getCurrentString);
+    Nan::SetPrototypeMethod(cursorTpl, "getCurrentBinary", CursorWrap::getCurrentBinary);
+    Nan::SetPrototypeMethod(cursorTpl, "getCurrentNumber", CursorWrap::getCurrentNumber);
+    Nan::SetPrototypeMethod(cursorTpl, "getCurrentBoolean", CursorWrap::getCurrentBoolean);
+    Nan::SetPrototypeMethod(cursorTpl, "goToFirst", CursorWrap::goToFirst);
+    Nan::SetPrototypeMethod(cursorTpl, "goToLast", CursorWrap::goToLast);
+    Nan::SetPrototypeMethod(cursorTpl, "goToNext", CursorWrap::goToNext);
+    Nan::SetPrototypeMethod(cursorTpl, "goToPrev", CursorWrap::goToPrev);
+    Nan::SetPrototypeMethod(cursorTpl, "goToKey", CursorWrap::goToKey);
+    Nan::SetPrototypeMethod(cursorTpl, "goToRange", CursorWrap::goToRange);
+    Nan::SetPrototypeMethod(cursorTpl, "goToFirstDup", CursorWrap::goToFirstDup);
+    Nan::SetPrototypeMethod(cursorTpl, "goToLastDup", CursorWrap::goToLastDup);
+    Nan::SetPrototypeMethod(cursorTpl, "goToNextDup", CursorWrap::goToNextDup);
+    Nan::SetPrototypeMethod(cursorTpl, "goToPrevDup", CursorWrap::goToPrevDup);
+    Nan::SetPrototypeMethod(cursorTpl, "goToDup", CursorWrap::goToDup);
+    Nan::SetPrototypeMethod(cursorTpl, "goToDupRange", CursorWrap::goToDupRange);
+    Nan::SetPrototypeMethod(cursorTpl, "del", CursorWrap::del);
 
     // Set exports
     exports->Set(Nan::New<String>("Cursor").ToLocalChecked(), cursorTpl->GetFunction());

--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -197,3 +197,11 @@ NAN_METHOD(DbiWrap::stat) {
 
     info.GetReturnValue().Set(obj);
 }
+
+NAN_GETTER(DbiWrap::getEnv) {
+    Nan::HandleScope scope;
+
+    DbiWrap *dw = Nan::ObjectWrap::Unwrap<DbiWrap>(info.This());
+
+    info.GetReturnValue().Set(dw->ew->handle());
+}

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -131,7 +131,7 @@ NAN_METHOD(EnvWrap::open) {
     setFlagFromValue(&flags, MDB_NOMETASYNC, "noMetaSync", false, options);
     setFlagFromValue(&flags, MDB_NOSYNC, "noSync", false, options);
     setFlagFromValue(&flags, MDB_MAPASYNC, "mapAsync", false, options);
-    
+
     // Set MDB_NOTLS to enable multiple read-only transactions on the same thread (in this case, the nodejs main thread)
     flags |= MDB_NOTLS;
 
@@ -252,10 +252,12 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     Nan::SetPrototypeMethod(txnTpl, "getBinary", TxnWrap::getBinary);
     Nan::SetPrototypeMethod(txnTpl, "getNumber", TxnWrap::getNumber);
     Nan::SetPrototypeMethod(txnTpl, "getBoolean", TxnWrap::getBoolean);
+    Nan::SetPrototypeMethod(txnTpl, "get", TxnWrap::get);
     Nan::SetPrototypeMethod(txnTpl, "putString", TxnWrap::putString);
     Nan::SetPrototypeMethod(txnTpl, "putBinary", TxnWrap::putBinary);
     Nan::SetPrototypeMethod(txnTpl, "putNumber", TxnWrap::putNumber);
     Nan::SetPrototypeMethod(txnTpl, "putBoolean", TxnWrap::putBoolean);
+    Nan::SetPrototypeMethod(txnTpl, "put", TxnWrap::put);
     Nan::SetPrototypeMethod(txnTpl, "del", TxnWrap::del);
     Nan::SetPrototypeMethod(txnTpl, "reset", TxnWrap::reset);
     Nan::SetPrototypeMethod(txnTpl, "renew", TxnWrap::renew);
@@ -268,10 +270,14 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     Local<FunctionTemplate> dbiTpl = Nan::New<FunctionTemplate>(DbiWrap::ctor);
     dbiTpl->SetClassName(Nan::New<String>("Dbi").ToLocalChecked());
     dbiTpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    Nan::SetAccessor(dbiTpl->InstanceTemplate(), Nan::New<String>("env").ToLocalChecked(), DbiWrap::getEnv);
+
     // DbiWrap: Add functions to the prototype
     Nan::SetPrototypeMethod(dbiTpl, "close", DbiWrap::close);
     Nan::SetPrototypeMethod(dbiTpl, "drop", DbiWrap::drop);
     Nan::SetPrototypeMethod(dbiTpl, "stat", DbiWrap::stat);
+
     // TODO: wrap mdb_stat too
     // DbiWrap: Get constructor
     EnvWrap::dbiCtor.Reset( dbiTpl->GetFunction());

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -284,4 +284,6 @@ void EnvWrap::setupExports(Handle<Object> exports) {
 
     // Set exports
     exports->Set(Nan::New<String>("Env").ToLocalChecked(), envTpl->GetFunction());
+
+    attachJson();
 }

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -232,11 +232,11 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     envTpl->SetClassName(Nan::New<String>("Env").ToLocalChecked());
     envTpl->InstanceTemplate()->SetInternalFieldCount(1);
     // EnvWrap: Add functions to the prototype
-    envTpl->PrototypeTemplate()->Set(Nan::New<String>("open").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::open)->GetFunction());
-    envTpl->PrototypeTemplate()->Set(Nan::New<String>("close").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::close)->GetFunction());
-    envTpl->PrototypeTemplate()->Set(Nan::New<String>("beginTxn").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::beginTxn)->GetFunction());
-    envTpl->PrototypeTemplate()->Set(Nan::New<String>("openDbi").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::openDbi)->GetFunction());
-    envTpl->PrototypeTemplate()->Set(Nan::New<String>("sync").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::sync)->GetFunction());
+    Nan::SetPrototypeMethod(envTpl, "open", EnvWrap::open);
+    Nan::SetPrototypeMethod(envTpl, "close", EnvWrap::close);
+    Nan::SetPrototypeMethod(envTpl, "beginTxn", EnvWrap::beginTxn);
+    Nan::SetPrototypeMethod(envTpl, "openDbi", EnvWrap::openDbi);
+    Nan::SetPrototypeMethod(envTpl, "sync", EnvWrap::sync);
     // TODO: wrap mdb_env_copy too
     // TODO: wrap mdb_env_stat too
     // TODO: wrap mdb_env_info too
@@ -246,19 +246,19 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     txnTpl->SetClassName(Nan::New<String>("Txn").ToLocalChecked());
     txnTpl->InstanceTemplate()->SetInternalFieldCount(1);
     // TxnWrap: Add functions to the prototype
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("commit").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::commit)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("abort").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::abort)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("getString").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::getString)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("getBinary").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::getBinary)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("getNumber").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::getNumber)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("getBoolean").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::getBoolean)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("putString").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::putString)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("putBinary").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::putBinary)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("putNumber").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::putNumber)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("putBoolean").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::putBoolean)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("del").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::del)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("reset").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::reset)->GetFunction());
-    txnTpl->PrototypeTemplate()->Set(Nan::New<String>("renew").ToLocalChecked(), Nan::New<FunctionTemplate>(TxnWrap::renew)->GetFunction());
+    Nan::SetPrototypeMethod(txnTpl, "commit", TxnWrap::commit);
+    Nan::SetPrototypeMethod(txnTpl, "abort", TxnWrap::abort);
+    Nan::SetPrototypeMethod(txnTpl, "getString", TxnWrap::getString);
+    Nan::SetPrototypeMethod(txnTpl, "getBinary", TxnWrap::getBinary);
+    Nan::SetPrototypeMethod(txnTpl, "getNumber", TxnWrap::getNumber);
+    Nan::SetPrototypeMethod(txnTpl, "getBoolean", TxnWrap::getBoolean);
+    Nan::SetPrototypeMethod(txnTpl, "putString", TxnWrap::putString);
+    Nan::SetPrototypeMethod(txnTpl, "putBinary", TxnWrap::putBinary);
+    Nan::SetPrototypeMethod(txnTpl, "putNumber", TxnWrap::putNumber);
+    Nan::SetPrototypeMethod(txnTpl, "putBoolean", TxnWrap::putBoolean);
+    Nan::SetPrototypeMethod(txnTpl, "del", TxnWrap::del);
+    Nan::SetPrototypeMethod(txnTpl, "reset", TxnWrap::reset);
+    Nan::SetPrototypeMethod(txnTpl, "renew", TxnWrap::renew);
     // TODO: wrap mdb_cmp too
     // TODO: wrap mdb_dcmp too
     // TxnWrap: Get constructor
@@ -269,9 +269,9 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     dbiTpl->SetClassName(Nan::New<String>("Dbi").ToLocalChecked());
     dbiTpl->InstanceTemplate()->SetInternalFieldCount(1);
     // DbiWrap: Add functions to the prototype
-    dbiTpl->PrototypeTemplate()->Set(Nan::New<String>("close").ToLocalChecked(), Nan::New<FunctionTemplate>(DbiWrap::close)->GetFunction());
-    dbiTpl->PrototypeTemplate()->Set(Nan::New<String>("drop").ToLocalChecked(), Nan::New<FunctionTemplate>(DbiWrap::drop)->GetFunction());
-    dbiTpl->PrototypeTemplate()->Set(Nan::New<String>("stat").ToLocalChecked(), Nan::New<FunctionTemplate>(DbiWrap::stat)->GetFunction());
+    Nan::SetPrototypeMethod(dbiTpl, "close", DbiWrap::close);
+    Nan::SetPrototypeMethod(dbiTpl, "drop", DbiWrap::drop);
+    Nan::SetPrototypeMethod(dbiTpl, "stat", DbiWrap::stat);
     // TODO: wrap mdb_stat too
     // DbiWrap: Get constructor
     EnvWrap::dbiCtor.Reset( dbiTpl->GetFunction());

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -52,6 +52,7 @@ Local<Value> valToString(MDB_val &data);
 Local<Value> valToBinary(MDB_val &data);
 Local<Value> valToNumber(MDB_val &data);
 Local<Value> valToBoolean(MDB_val &data);
+Local<Value> valToVal(MDB_val &data);
 
 /*
     `Env`
@@ -256,6 +257,20 @@ public:
     static NAN_METHOD(getBoolean);
 
     /*
+        Gets data associated with the given key from a database. You need to open a database in the environment to use this.
+        When data is Number or Boolean this method will copy the value out of the database.
+        When data is String or Buffer this method is zero-copy and the return value can only be used until the next put
+        operation or until the transaction is committed or aborted.
+        (Wrapper for `mdb_get`)
+
+        Parameters:
+
+        * database instance created with calling `openDbi()` on an `Env` instance
+        * key for which the value is retrieved
+    */
+    static NAN_METHOD(get);
+
+    /*
         Puts string data (JavaScript string type) into a database.
         (Wrapper for `mdb_put`)
 
@@ -302,6 +317,18 @@ public:
         * data to store for the given key
     */
     static NAN_METHOD(putBoolean);
+
+    /*
+        Puts data into a database.
+        (Wrapper for `mdb_put`)
+
+        Parameters:
+
+        * database instance created with calling `openDbi()` on an `Env` instance
+        * key for which the value is stored
+        * data to store for the given key
+    */
+    static NAN_METHOD(put);
 
     /*
         Deletes data with the given key from the database.
@@ -360,6 +387,8 @@ public:
     static NAN_METHOD(drop);
 
     static NAN_METHOD(stat);
+
+    static NAN_GETTER(getEnv);
 };
 
 /*
@@ -459,6 +488,16 @@ public:
     static NAN_METHOD(getCurrentBoolean);
 
     /*
+        Gets the current key-data pair that the cursor is pointing to.
+        (Wrapper for `mdb_cursor_get`)
+
+        Parameters:
+
+        * Callback that accepts the key and value
+    */
+    static NAN_METHOD(getCurrent);
+
+    /*
         Asks the cursor to go to the first key-data pair in the database.
         (Wrapper for `mdb_cursor_get`)
     */
@@ -552,6 +591,22 @@ public:
     size_t length() const;
 
     static void writeTo(Handle<String> str, MDB_val *val);
+};
+
+#define TYPE_UNKNOWN 0
+#define TYPE_BINARY 1
+#define TYPE_STRING 2
+#define TYPE_NUMBER 3
+#define TYPE_BOOLEAN 4
+
+struct NumberData {
+    char type;
+    double data;
+};
+
+struct BooleanData {
+    char type;
+    bool data;
 };
 
 #endif // NODE_LMDB_H

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -33,6 +33,13 @@
 
 #define NanReturnThis() return info.GetReturnValue().Set(info.This())
 
+#define TYPE_UNKNOWN 0
+#define TYPE_BINARY 1
+#define TYPE_STRING 2
+#define TYPE_NUMBER 3
+#define TYPE_BOOLEAN 4
+#define TYPE_OBJECT 5
+
 using namespace v8;
 using namespace node;
 
@@ -283,6 +290,18 @@ public:
     static NAN_METHOD(putString);
 
     /*
+        Puts object data into a database.
+        (Wrapper for `mdb_put`)
+
+        Parameters:
+
+        * database instance created with calling `openDbi()` on an `Env` instance
+        * key for which the value is stored
+        * data to store for the given key
+    */
+    static NAN_METHOD(putObject);
+
+    /*
         Puts binary data (Node.js Buffer) into a database.
         (Wrapper for `mdb_put`)
 
@@ -495,7 +514,7 @@ public:
 
         * Callback that accepts the key and value
     */
-    static NAN_METHOD(getCurrent);
+    static NAN_METHOD(get);
 
     /*
         Asks the cursor to go to the first key-data pair in the database.
@@ -590,14 +609,8 @@ public:
     const uint16_t *data() const;
     size_t length() const;
 
-    static void writeTo(Handle<String> str, MDB_val *val);
+    static void writeTo(Handle<String> str, MDB_val *val, char type = TYPE_STRING);
 };
-
-#define TYPE_UNKNOWN 0
-#define TYPE_BINARY 1
-#define TYPE_STRING 2
-#define TYPE_NUMBER 3
-#define TYPE_BOOLEAN 4
 
 struct NumberData {
     char type;
@@ -608,5 +621,9 @@ struct BooleanData {
     char type;
     bool data;
 };
+
+void attachJson();
+Local<String> ValueToJson(Handle<Value> value);
+Local<Value> ValueFromJson(Handle<String> json);
 
 #endif // NODE_LMDB_H

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 'use strict';
+/* global describe, before, it, after */
 
 var path = require('path');
 var mkdirp = require('mkdirp');
@@ -15,14 +16,14 @@ describe('Node.js LMDB Bindings', function() {
     // cleanup previous test directory
     rimraf(testDirPath, function(err) {
       if (err) {
-	return done(err);
+        return done(err);
       }
       // setup clean directory
       mkdirp(testDirPath, function(err) {
-	if (err) {
-	  return done(err);
-	}
-	done();
+        if (err) {
+          return done(err);
+        }
+        done();
       });
     });
   });
@@ -43,8 +44,8 @@ describe('Node.js LMDB Bindings', function() {
     before(function() {
       env = new lmdb.Env();
       env.open({
-	path: testDirPath,
-	maxDbs: 10
+        path: testDirPath,
+        maxDbs: 10
       });
     });
     after(function() {
@@ -52,8 +53,8 @@ describe('Node.js LMDB Bindings', function() {
     });
     it('will open a database, begin a transaction and get/put/delete data', function() {
       var dbi = env.openDbi({
-	name: 'mydb1',
-	create: true
+        name: 'mydb1',
+        create: true
       });
       var txn = env.beginTxn();
       var data = txn.getString(dbi, 'hello');
@@ -69,8 +70,8 @@ describe('Node.js LMDB Bindings', function() {
     });
     it('will get statistics for a database', function() {
       var dbi = env.openDbi({
-	name: 'mydb2',
-	create: true
+        name: 'mydb2',
+        create: true
       });
       var txn = env.beginTxn();
       var stat = dbi.stat(txn);
@@ -90,12 +91,12 @@ describe('Node.js LMDB Bindings', function() {
     before(function() {
       env = new lmdb.Env();
       env.open({
-	path: testDirPath,
-	maxDbs: 10
+        path: testDirPath,
+        maxDbs: 10
       });
       dbi = env.openDbi({
-	name: 'mydb3',
-	create: true
+        name: 'mydb3',
+        create: true
       });
       txn = env.beginTxn();
     });
@@ -144,19 +145,80 @@ describe('Node.js LMDB Bindings', function() {
       should.equal(data4, null);
     });
   });
+  describe('Auto data types', function() {
+    var env;
+    var dbi;
+    var txn;
+    before(function() {
+      env = new lmdb.Env();
+      env.open({
+        path: testDirPath,
+        maxDbs: 10
+      });
+      dbi = env.openDbi({
+        name: 'mydb3',
+        create: true
+      });
+      txn = env.beginTxn();
+    });
+    after(function() {
+      txn.commit();
+      dbi.close();
+      env.close();
+    });
+    it('string', function() {
+      txn.put(dbi, 'key1', 'Hello world!');
+      var data = txn.get(dbi, 'key1');
+      data.should.equal('Hello world!');
+      txn.del(dbi, 'key1');
+      var data2 = txn.get(dbi, 'key1');
+      should.equal(data2, null);
+    });
+    it('binary', function() {
+      var buffer = new Buffer('48656c6c6f2c20776f726c6421', 'hex');
+      txn.put(dbi, 'key2', buffer);
+      var data = txn.get(dbi, 'key2');
+      data.should.deep.equal(buffer);
+      txn.del(dbi, 'key2');
+      var data2 = txn.get(dbi, 'key2');
+      should.equal(data2, null);
+    });
+    it('number', function() {
+      txn.put(dbi, 'key3', 9007199254740991);
+      var data = txn.get(dbi, 'key3');
+      data.should.equal(Math.pow(2, 53) - 1);
+      txn.del(dbi, 'key3');
+      var data2 = txn.get(dbi, 'key3');
+      should.equal(data2, null);
+    });
+    it('boolean', function() {
+      txn.putBoolean(dbi, 'key4', true);
+      var data = txn.get(dbi, 'key4');
+      data.should.equal(true);
+      txn.put(dbi, 'key5', false);
+      var data2 = txn.get(dbi, 'key5');
+      data2.should.equal(false);
+      txn.del(dbi, 'key4');
+      txn.del(dbi, 'key5');
+      var data3 = txn.get(dbi, 'key4');
+      var data4 = txn.get(dbi, 'key5');
+      should.equal(data3, null);
+      should.equal(data4, null);
+    });
+  });
   describe('Multiple transactions', function() {
     var env;
     var dbi;
     before(function() {
       env = new lmdb.Env();
       env.open({
-	path: testDirPath,
-	maxDbs: 10
+        path: testDirPath,
+        maxDbs: 10
       });
       dbi = env.openDbi({
-	name: 'mydb4',
-	create: true,
-	keyIsUint32: true
+        name: 'mydb4',
+        create: true,
+        keyIsUint32: true
       });
       var txn = env.beginTxn();
       txn.putString(dbi, 1, 'Hello1');
@@ -194,7 +256,7 @@ describe('Node.js LMDB Bindings', function() {
     it('readonly transaction will throw if tries to write', function() {
       var readTxn = env.beginTxn({readOnly: true});
       (function() {
-	readTxn.putString(dbi, 2, 'hööhh')
+        readTxn.putString(dbi, 2, 'hööhh');
       }).should.throw('Permission denied');
       readTxn.abort();
     });
@@ -207,23 +269,23 @@ describe('Node.js LMDB Bindings', function() {
     before(function() {
       env = new lmdb.Env();
       env.open({
-	path: testDirPath,
-	maxDbs: 10,
-	mapSize: 16 * 1024 * 1024 * 1024
+        path: testDirPath,
+        maxDbs: 10,
+        mapSize: 16 * 1024 * 1024 * 1024
       });
       dbi = env.openDbi({
-	name: 'mydb5',
-	create: true,
-	dupSort: true,
-	keyIsUint32: true
+        name: 'mydb5',
+        create: true,
+        dupSort: true,
+        keyIsUint32: true
       });
       var txn = env.beginTxn();
       var c = 0;
       while(c < total) {
-	var buffer = new Buffer(new Array(8));
-	buffer.writeDoubleBE(c);
-	txn.putBinary(dbi, c, buffer);
-	c++;
+        var buffer = new Buffer(new Array(8));
+        buffer.writeDoubleBE(c);
+        txn.putBinary(dbi, c, buffer);
+        c++;
       }
       txn.commit();
     });
@@ -236,21 +298,21 @@ describe('Node.js LMDB Bindings', function() {
       var cursor = new lmdb.Cursor(txn, dbi);
       cursor.goToKey(40);
       cursor.getCurrentBinary(function(key, value) {
-	key.should.equal(40);
-	value.readDoubleBE().should.equal(40);
+        key.should.equal(40);
+        value.readDoubleBE().should.equal(40);
       });
 
       var values = [];
       cursor.goToKey(0);
       function iterator() {
-	cursor.getCurrentBinary(function(key, value) {
-	  value.readDoubleBE().should.equal(values.length);
-	  values.push(value);
-	});
-	cursor.goToNext();
-	if (values.length < total) {
-	  fastFuture(iterator);
-	}
+        cursor.getCurrentBinary(function(key, value) {
+          value.readDoubleBE().should.equal(values.length);
+          values.push(value);
+        });
+        cursor.goToNext();
+        if (values.length < total) {
+          fastFuture(iterator);
+        }
       }
       cursor.close();
       txn.abort();
@@ -260,13 +322,13 @@ describe('Node.js LMDB Bindings', function() {
       var cursor = new lmdb.Cursor(txn, dbi);
       cursor.goToFirst();
       cursor.getCurrentBinary(function(key, value) {
-	key.should.equal(0);
-	value.readDoubleBE().should.equal(0);
+        key.should.equal(0);
+        value.readDoubleBE().should.equal(0);
       });
       cursor.goToLast();
       cursor.getCurrentBinary(function(key, value) {
-	key.should.equal(total - 1);
-	value.readDoubleBE().should.equal(total - 1);
+        key.should.equal(total - 1);
+        value.readDoubleBE().should.equal(total - 1);
       });
       cursor.close();
       txn.abort();

--- a/test/index.js
+++ b/test/index.js
@@ -192,7 +192,7 @@ describe('Node.js LMDB Bindings', function() {
       should.equal(data2, null);
     });
     it('boolean', function() {
-      txn.putBoolean(dbi, 'key4', true);
+      txn.put(dbi, 'key4', true);
       var data = txn.get(dbi, 'key4');
       data.should.equal(true);
       txn.put(dbi, 'key5', false);
@@ -204,6 +204,21 @@ describe('Node.js LMDB Bindings', function() {
       var data4 = txn.get(dbi, 'key5');
       should.equal(data3, null);
       should.equal(data4, null);
+    });
+    it('object', function() {
+      var obj = {a: 'Hello world!', b: 9007199254740991, c: true};
+      txn.put(dbi, 'key6', obj);
+      var data = txn.get(dbi, 'key6');
+      data.should.deep.equal(obj);
+      txn.del(dbi, 'key6');
+      var data2 = txn.get(dbi, 'key6');
+      should.equal(data2, null);
+    });
+    it('null', function() {
+      txn.put(dbi, 'key7', true);
+      txn.put(dbi, 'key7', null);
+      var data = txn.get(dbi, 'key7');
+      should.equal(data, null);
     });
   });
   describe('Multiple transactions', function() {


### PR DESCRIPTION
I have extended the library with `put` and `get` methods accepting free value types. It is more comfortable to use. Also, prototype methods assignments need update due to deprecation warning. Internally in LMDB, value type is set by the first byte of data. Modification have 2 drawbacks:

- incompatability with previous data file format (1st byte is type now)
- binary type write performance degrade because of buffer copying

Regards!
