### PR TITLE
Use bindings module to load native addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./build/Release/node-lmdb');
+module.exports = require('bindings')('node-lmdb.node');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "gypfile": true,
   "dependencies": {
+    "bindings": "^1.2.1",
     "nan": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Handles case that the `.node` addon is compiled at a different location, such as:
```
build/Debug/node-lmdb.node
```