### PR TITLE
Flag for ready-only transaction when opening database

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "nan": "^2.3.5"
   },
   "devDependencies": {
-    "async": "^1.5.2",
     "chai": "^3.5.0",
     "fast-future": "^1.0.1",
     "mkdirp": "^0.5.1",

--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -59,6 +59,7 @@ NAN_METHOD(DbiWrap::ctor) {
     MDB_txn *txn;
     int rc;
     int flags = 0;
+    int txnFlags = 0;
     int keyIsUint32 = 0;
     Local<String> name;
     bool nameIsNull = false;
@@ -88,13 +89,19 @@ NAN_METHOD(DbiWrap::ctor) {
         if (keyIsUint32) {
             flags |= MDB_INTEGERKEY;
         }
+
+        // Set flags for txn used to open database
+        Local<Value> create = options->Get(Nan::New<String>("create").ToLocalChecked());
+        if (create->IsBoolean() ? !create->BooleanValue() : false) {
+            txnFlags |= MDB_RDONLY;
+        }
     }
     else {
         return Nan::ThrowError("Invalid parameters.");
     }
 
     // Open transaction
-    rc = mdb_txn_begin(ew->env, nullptr, 0, &txn);
+    rc = mdb_txn_begin(ew->env, nullptr, txnFlags, &txn);
     if (rc != 0) {
         mdb_txn_abort(txn);
         return Nan::ThrowError(mdb_strerror(rc));


### PR DESCRIPTION
If the database is not being created use a read-only transaction when opening a database so that coordination between multiple processes isn't necessary when spawning a read-only cluster.

A nice benefit of this is that a cluster can use a read-only environment so that any attempt to open a write txn will get "Error: Permission denied", and avoid conflicts with other write transactions.