### PR TITLE
Clear c++ only compile warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,8 +24,10 @@
           ],
           "cflags": [
             "-fPIC",
+            "-O3"
+          ],
+          "cflags_cc": [
             "-fvisibility-inlines-hidden",
-            "-O3",
             "-std=c++0x"
           ]
         }],


### PR DESCRIPTION
Clears these warnings:
```
cc1: warning: command line option ‘-std=c++11’ is valid for C++/ObjC++ but not for C
cc1: warning: command line option ‘-fvisibility-inlines-hidden’ is valid for C++/ObjC++ but not for C
```
Verbose build logs:
```
V=1 npm install
```