### PR TITLE
Fixed goToDup() and goToDupRange() bug in Cursor

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -209,11 +209,11 @@ NAN_METHOD(CursorWrap::goToRange) {
 
 static void fillDataFromArg1(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val &data) {
     if (info[1]->IsString()) {
-        CustomExternalStringResource::writeTo(info[2]->ToString(), &data);
+        CustomExternalStringResource::writeTo(info[1]->ToString(), &data);
     }
     else if (node::Buffer::HasInstance(info[1])) {
-        data.mv_size = node::Buffer::Length(info[2]);
-        data.mv_data = node::Buffer::Data(info[2]);
+        data.mv_size = node::Buffer::Length(info[1]);
+        data.mv_data = node::Buffer::Data(info[1]);
     }
     else if (info[1]->IsNumber()) {
         data.mv_size = sizeof(double);


### PR DESCRIPTION
Fixes #76.

I'm not sure how long this bug has been in, but in `fillDataFromArg1()` in cursor.cpp, if `info[1]` was a string or buffer, `cw->data` was being initialized from `info[2]` instead, the *third* argument to `goToDup()` or `goToDupRange()`, not the second. As only two arguments are expected to be passed, it's unlikely to work as documented.

I'd run into this problem when changing my current app to use `dupSort: true` instead of manual bucketing -- it wasn't working, I couldn't figure out why, and I was tearing hair and rending garments. Then, when I was looking through `fillDataFromArg1()`, I spent all afternoon staring at v8 and Nan documentation, trying to figure out if there was something about `Nan::NAN_METHOD_ARGS_TYPE` I wasn't understanding, some implicit argument passed in, *something*.

Anyways, it's a quick fix, and makes `goToDup()` or `goToDupRange()` work as expected.

Test script (assumes a subdir called `lmdb-test` in the script's directory):
```javascript
const path = require('path');
const lmdb = require('node-lmdb');
function printfn (k, v) {
	console.log('key:', k, 'value:', v);
}

function expect (expkey, expval) {
	var actkey, actval;
	console.log('Expected key: ' + expkey + ', value: ' + expval);
	key = cur.getCurrentString((k, v) => {
		actkey = k;
		actval = v;
	});
	if (actkey) {
		console.log('Actual key: ' + actkey + ', value: ' + actval);
	}
	else {
		console.log('Actual key: ' + key + ', value: (not retrieved)');
	}
}

var env = new lmdb.Env();
env.open({path: path.resolve(__dirname, 'lmdb-test'), mapSize: 128*1024*1024, maxDbs: 4, maxReaders: 4});
var db = env.openDbi({name: 'test', create: true, dupSort: true});
db.drop();
db = env.openDbi({name: 'test', create: true, dupSort: true});
var txn, cur, key;

console.log('Writing test data...');
txn = env.beginTxn();
txn.putString(db, 'beep', 'boop');
txn.putString(db, 'beep', 'booo!');
txn.putString(db, 'blam', 'blah');
txn.putString(db, 'blam', 'badump');
txn.putString(db, 'ergh', 'asdf');
txn.commit();
console.log();

console.log('Reading test data...');
txn = env.beginTxn({readOnly: true});
cur = new lmdb.Cursor(txn, db);
key = cur.goToFirst();
do {
	cur.getCurrentString(printfn);
	key = cur.goToNextDup();
	if (!key) {
		key = cur.goToNext();
	}
} while (key);
cur.close();
txn.commit();
console.log();


// Now for the bug
txn = env.beginTxn({readOnly: true});
cur = new lmdb.Cursor(txn, db);

console.log('With 2 arguments...\n');
console.log("Testing: cur.goToDup('blam', 'badump')");
key = cur.goToDup('blam', 'badump');
expect('blam', 'badump');
console.log();
console.log("Testing: cur.goToDupRange('beep', 'booo')");
key = cur.goToDupRange('beep', 'booo');
expect('beep', 'booo!');
console.log();

console.log('With 3 arguments...\n');
console.log("Testing: cur.goToDup('blam', 'badump', 'badump')");
key = cur.goToDup('blam', 'badump', 'badump');
expect('blam', 'badump');
console.log();
console.log("Testing: cur.goToDupRange('beep', 'booo', 'booo')");
key = cur.goToDupRange('beep', 'booo', 'booo');
expect('beep', 'booo!');
console.log();

cur.close();
txn.commit();

db.close();
env.close();
```