### PR TITLE
Support using `txn.del()` with key/data pair when dupSort enabled

### DIFF
--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -126,6 +126,7 @@ NAN_METHOD(DbiWrap::ctor) {
     dw->ew = ew;
     dw->ew->Ref();
     dw->keyIsUint32 = keyIsUint32;
+    dw->flags = flags;
     dw->Wrap(info.This());
 
     NanReturnThis();

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -348,6 +348,8 @@ class DbiWrap : public Nan::ObjectWrap {
 private:
     // Stores whether keys should be treated as uint32_t
     bool keyIsUint32;
+    // Stores flags set when opened
+    int flags;
     // The wrapped object
     MDB_dbi dbi;
     // Reference to the MDB_env of the wrapped MDB_dbi


### PR DESCRIPTION
Fixes #79.

`txn.del()` will now use the third argument, if given and if dupSort is enabled on the dbi, and pass it to `mdb_del()`. This allows deletion of a specific key/value pair, instead of deleting all entries with the given key.

I've also added the flags used when opening as a member of DbiWrap, which could prove useful in other things as well.
