### PR TITLE
Clear node-gyp rebuild warnings with Node.js v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.3.5"
+    "nan": "^2.4"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -225,7 +225,7 @@ static void fillDataFromArg1(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB
     else if (info[1]->IsNumber()) {
         data.mv_size = sizeof(double);
         data.mv_data = new double;
-        *((double*)data.mv_data) = info[1]->ToNumber()->Value();
+        *((double*)data.mv_data) = info[1]->ToNumber(Nan::GetCurrentContext()).ToLocalChecked()->Value();
     }
     else if (info[1]->IsBoolean()) {
         data.mv_size = sizeof(double);

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -164,10 +164,10 @@ NAN_METHOD(EnvWrap::close) {
 NAN_METHOD(EnvWrap::beginTxn) {
     Nan::HandleScope scope;
 
-    const unsigned argc = 2;
+    const int argc = 2;
 
     Local<Value> argv[argc] = { info.This(), info[0] };
-    Local<Object> instance = Nan::New(txnCtor)->NewInstance(argc, argv);
+    Local<Object> instance = Nan::New(txnCtor)->NewInstance(Nan::GetCurrentContext(), argc, argv).ToLocalChecked();
 
     info.GetReturnValue().Set(instance);
 }
@@ -177,7 +177,7 @@ NAN_METHOD(EnvWrap::openDbi) {
 
     const unsigned argc = 2;
     Local<Value> argv[argc] = { info.This(), info[0] };
-    Local<Object> instance = Nan::New(dbiCtor)->NewInstance(argc, argv);
+    Local<Object> instance = Nan::New(dbiCtor)->NewInstance(Nan::GetCurrentContext(), argc, argv).ToLocalChecked();
 
     info.GetReturnValue().Set(instance);
 }

--- a/src/txn.cpp
+++ b/src/txn.cpp
@@ -241,7 +241,7 @@ NAN_METHOD(TxnWrap::putNumber) {
     return putCommon(info, [](Nan::NAN_METHOD_ARGS_TYPE info, MDB_val &data) -> void {
         data.mv_size = sizeof(double);
         data.mv_data = new double;
-        *((double*)data.mv_data) = info[2]->ToNumber()->Value();
+        *((double*)data.mv_data) = info[2]->ToNumber(Nan::GetCurrentContext()).ToLocalChecked()->Value();
     }, [](MDB_val &data) -> void {
         delete (double*)data.mv_data;
     });


### PR DESCRIPTION
Clears build warnings when running `node-gyp rebuild` with Node.js v6, mentioned in https://github.com/Venemo/node-lmdb/issues/81

Note: This is not compatible with versions 0.12 and 0.10, though maintanance support is being dropped in Oct. and Dec. https://github.com/nodejs/LTS