### PR TITLE
Key as buffer

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -96,7 +96,8 @@ Nan::NAN_METHOD_RETURN_TYPE CursorWrap::getCommon(
     void (*setKey)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
     void (*setData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
     void (*freeData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
-    Local<Value> (*convertFunc)(MDB_val &data)
+    Local<Value> (*convertFunc)(MDB_val &data),
+    bool keyAsBuffer
 ) {
     Nan::HandleScope scope;
 
@@ -126,7 +127,7 @@ Nan::NAN_METHOD_RETURN_TYPE CursorWrap::getCommon(
 
     Local<Value> keyHandle = Nan::Undefined();
     if (cw->key.mv_size) {
-        keyHandle = keyToHandle(cw->key, cw->keyIsUint32);
+        keyHandle = keyToHandle(cw->key, cw->keyIsUint32, keyAsBuffer);
     }
 
     Local<Value> dataHandle = Nan::Undefined();
@@ -169,11 +170,11 @@ NAN_METHOD(CursorWrap::getCurrentStringUnsafe) {
 }
 
 NAN_METHOD(CursorWrap::getCurrentBinary) {
-    return getCommon(info, MDB_GET_CURRENT, nullptr, nullptr, nullptr, valToBinary);
+    return getCommon(info, MDB_GET_CURRENT, nullptr, nullptr, nullptr, valToBinary, true);
 }
 
 NAN_METHOD(CursorWrap::getCurrentBinaryUnsafe) {
-    return getCommon(info, MDB_GET_CURRENT, nullptr, nullptr, nullptr, valToBinaryUnsafe);
+    return getCommon(info, MDB_GET_CURRENT, nullptr, nullptr, nullptr, valToBinaryUnsafe, true);
 }
 
 NAN_METHOD(CursorWrap::getCurrentNumber) {

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -92,11 +92,12 @@ argtokey_callback_t argToKey(const Local<Value> &val, MDB_val &key, bool keyIsUi
     return nullptr;
 }
 
-Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32) {
+Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32, bool keyAsBuffer) {
     if (keyIsUint32) {
         return Nan::New<Integer>(*((uint32_t*)key.mv_data));
-    }
-    else {
+    } else if (keyAsBuffer) {
+        return valToBinary(key);
+    } else {
         return valToString(key);
     }
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -53,6 +53,18 @@ argtokey_callback_t argToKey(const Local<Value> &val, MDB_val &key, bool keyIsUi
         Nan::ThrowError("Invalid key. keyIsUint32 specified on the database, but the given key was not an unsigned 32-bit integer");
         return nullptr;
     }
+
+    // Handle buffer
+    if (node::Buffer::HasInstance(val)) {
+        key.mv_size = node::Buffer::Length(val);
+        key.mv_data = node::Buffer::Data(val);
+
+        return ([](MDB_val &key) -> void {
+           // We shouldn't need free here - need to clarify
+        });
+
+    }
+
     if (!keyIsUint32 && !val->IsString()) {
         Nan::ThrowError("Invalid key. String key expected, because keyIsUint32 isn't specified on the database.");
         return nullptr;

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -47,7 +47,7 @@ void consoleLog(const char *msg);
 void consoleLogN(int n);
 void setFlagFromValue(int *flags, int flag, const char *name, bool defaultValue, Local<Object> options);
 argtokey_callback_t argToKey(const Local<Value> &val, MDB_val &key, bool keyIsUint32);
-Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32);
+Local<Value> keyToHandle(MDB_val &key, bool keyIsUint32, bool keyAsBuffer = false);
 Local<Value> valToString(MDB_val &data);
 Local<Value> valToStringUnsafe(MDB_val &data);
 Local<Value> valToBinary(MDB_val &data);
@@ -439,7 +439,8 @@ public:
         void (*setKey)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
         void (*setData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
         void (*freeData)(CursorWrap* cw, Nan::NAN_METHOD_ARGS_TYPE info, MDB_val&),
-        Local<Value> (*convertFunc)(MDB_val &data));
+        Local<Value> (*convertFunc)(MDB_val &data),
+        bool keyAsBuffer = false);
 
     // Helper method for getters (not exposed)
     static Nan::NAN_METHOD_RETURN_TYPE getCommon(Nan::NAN_METHOD_ARGS_TYPE info, MDB_cursor_op op);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,6 +138,16 @@ describe('Node.js LMDB Bindings', function() {
       var data2 = txn.getBinaryUnsafe(dbi, 'key2');
       should.equal(data2, null);
     });
+    it('binary key', function() {
+      var buffer = new Buffer('48656c6c6f2c20776f726c6421', 'hex');
+      var key = new Buffer('key2');
+      txn.putBinary(dbi, key, buffer);
+      var data = txn.getBinary(dbi, key);
+      data.should.deep.equal(buffer);
+      txn.del(dbi, key);
+      var data2 = txn.getBinary(dbi, key);
+      should.equal(data2, null);
+    });
     it('number', function() {
       txn.putNumber(dbi, 'key3', 9007199254740991);
       var data = txn.getNumber(dbi, 'key3');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -490,21 +490,21 @@ describe('Node.js LMDB Bindings', function() {
       var txn = env.beginTxn();
       var value1 = new Buffer(new Array(8));
       var value2 = new Buffer(new Array(4));
-      txn.putBinary(dbi, 'id', value1);
-      txn.putBinary(dbi, 'id', value2);
+      txn.putBinary(dbi, new Buffer('id'), value1);
+      txn.putBinary(dbi, new Buffer('id'), value2);
       txn.commit();
 
       var txn2 = env.beginTxn({readonly: true});
       var cursor = new lmdb.Cursor(txn2, dbi);
-      var found = cursor.goToKey('id');
+      var found = cursor.goToKey(new Buffer('id'));
       should.exist(found);
       cursor.getCurrentBinary(function(key, value) {
-        key.should.equal('id');
+        key.toString().should.equal('id');
         value.length.should.equal(4);
 
         cursor.goToNext();
         cursor.getCurrentBinary(function(key, value) {
-          key.should.equal('id');
+          key.toString().should.equal('id');
           value.length.should.equal(8);
           cursor.close();
           txn2.abort();
@@ -541,21 +541,21 @@ describe('Node.js LMDB Bindings', function() {
       value1.writeUInt32BE(100);
       var value2 = new Buffer(new Array(8));
       value2.writeUInt32BE(200);
-      txn.putBinary(dbi, 'id', value1);
-      txn.putBinary(dbi, 'id', value2);
+      txn.putBinary(dbi, new Buffer('id'), value1);
+      txn.putBinary(dbi, new Buffer('id'), value2);
       txn.commit();
 
       var txn2 = env.beginTxn({readonly: true});
       var cursor = new lmdb.Cursor(txn2, dbi);
-      var found = cursor.goToKey('id');
+      var found = cursor.goToKey(new Buffer('id'));
       should.exist(found);
       cursor.getCurrentBinary(function(key, value) {
-        key.should.equal('id');
+        key.toString().should.equal('id');
         value.length.should.equal(8);
 
         cursor.goToNext();
         cursor.getCurrentBinary(function(key, value) {
-          key.should.equal('id');
+          key.toString().should.equal('id');
           value.length.should.equal(8);
           cursor.close();
           txn2.abort();
@@ -566,7 +566,7 @@ describe('Node.js LMDB Bindings', function() {
   });
   describe('Memory Freeing / Garbage Collection', function() {
     it('should not cause a segment fault', function(done) {
-      var expectedKey = '822285ee315d2b04';
+      var expectedKey = new Buffer('822285ee315d2b04');
       var expectedValue = new Buffer('ec65d632d9168c33350ed31a30848d01e95172931e90984c218ef6b08c1fa90a', 'hex');
       var env = new lmdb.Env();
       env.open({
@@ -594,7 +594,7 @@ describe('Node.js LMDB Bindings', function() {
       txn2.abort();
       dbi.close();
       env.close();
-      key.should.equal(expectedKey);
+      key.should.deep.equal(expectedKey);
       value.compare(expectedValue).should.equal(0);
       done();
     });
@@ -616,7 +616,7 @@ describe('Node.js LMDB Bindings', function() {
         create: true
       });
       var txn = env.beginTxn();
-      txn.putBinary(dbi, expectedKey.toString('hex'), expectedValue);
+      txn.putBinary(dbi, expectedKey, expectedValue);
       txn.commit();
     });
     after(function() {


### PR DESCRIPTION
This adds the feature to use keys as buffers, and to give buffers for keys from `getCurrentBinary`.

Related: https://github.com/Venemo/node-lmdb/issues/47