### PR TITLE
Fixes #85 - Throw error if named dbi was not found

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,8 +33,9 @@
         }],
         ["OS=='mac'", {
           "xcode_settings": {
-            "OTHER_CPLUSPLUSFLAGS" : ["-std=c++11","-mmacosx-version-min=10.7"],
+            "OTHER_CPLUSPLUSFLAGS" : ["-std=c++11", "-mmacosx-version-min=10.7"],
             "OTHER_LDFLAGS": ["-std=c++11"],
+            "CLANG_CXX_LIBRARY": "libc++"
           }
         }],
       ],

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -177,7 +177,16 @@ NAN_METHOD(EnvWrap::openDbi) {
 
     const unsigned argc = 2;
     Local<Value> argv[argc] = { info.This(), info[0] };
-    Local<Object> instance = Nan::New(dbiCtor)->NewInstance(Nan::GetCurrentContext(), argc, argv).ToLocalChecked();
+
+    MaybeLocal<Object> maybeInstance = Nan::New(dbiCtor)->NewInstance(Nan::GetCurrentContext(), argc, argv);
+
+    //Check if database could be opened
+    if((maybeInstance.IsEmpty())){
+        // TODO: How to get error thrown in dbiCtor on mdb_dbi_open ? MDB_NOTFOUND or MDB_DBS_FULL
+        return Nan::ThrowError("No Dbi found or too many databases open");
+    }
+
+    Local<Object> instance = maybeInstance.ToLocalChecked();
 
     info.GetReturnValue().Set(instance);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,6 +67,16 @@ describe('Node.js LMDB Bindings', function() {
       txn.commit();
       dbi.close();
     });
+    it('will throw Javascript error if named database cannot be found', function () {
+      try {
+        env.openDbi({
+          name: 'does-not-exist',
+          create: false
+        });
+      } catch (err) {
+        err.should.be.an.instanceof(Error);
+      }
+    });
     it('will get statistics for a database', function() {
       var dbi = env.openDbi({
         name: 'mydb2',


### PR DESCRIPTION
Fixes #85

This solves the problem described in the issue by checking if the `MaybeLocal` is empty and throwing a Javascript exception if so.

This is not optimal, as the exception originally thrown in [DbiWrap::ctor](https://github.com/Venemo/node-lmdb/blob/master/src/dbi.cpp#L107) contains the exact reason why `mdb_dbi_open` failed, but I have no idea how to access the original exception which seems to be catched in `Nan::New(dbiCtor)->NewInstance`

I am not profound enough with C++/NaN to find a better solution to this, maybe some one else can help out?


I also added a test case in the JS test suit to cover this use case, so any better solution can check against that.

