### PR TITLE
don't delay loading node.exe due to imported data

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,6 +2,7 @@
   "targets": [
     {
       "target_name": "node-lmdb",
+      'win_delay_load_hook': 'false',
       "sources": [
         "dependencies/lmdb/libraries/liblmdb/mdb.c",
         "dependencies/lmdb/libraries/liblmdb/midl.c",


### PR DESCRIPTION
Because `CustomeExternalStringResource` extends V8's `ExternalStringResource`, it imports the vftable which prevents delayed loading of `node.exe`. Attempting to build the module with `node-gyp` results in the error [LNK1194](https://msdn.microsoft.com/en-us/library/aa699254(v=vs.60).aspx)

```
LINK : fatal error LNK1194: cannot delay-load 'node.exe' due to import of data symbol '"__declspec(dllimport) const v8:
:String::ExternalStringResource::`vftable'" (__imp_??_7ExternalStringResource@String@v8@@6B@)'; link without /DELAYLOAD
:node.exe [D:\tmp\lmdb\node-lmdb\build\node-lmdb.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Program Files (x86)\Yarn\node_modules\node-gyp\lib\build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Windows_NT 10.0.14393
gyp ERR! command "C:\\Program Files (x86)\\nodejs\\node.exe" "C:\\Program Files (x86)\\Yarn\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd D:\tmp\lmdb\node-lmdb
gyp ERR! node -v v7.7.2
gyp ERR! node-gyp -v v3.5.0
gyp ERR! not ok
error Command failed with exit code 1.
```

Further discussion:
nodejs/node#1266 - flag to disable delayed load
nodejs/node-gyp#599 - background
nodejs/node#751 - technical details
nodejs/node#1251 - technical details
