### PR TITLE
Resize functionality

### DIFF
--- a/examples/12-largedb-resize.js
+++ b/examples/12-largedb-resize.js
@@ -1,0 +1,67 @@
+
+/*
+    Example that shows how to use node-lmdb with LARGE databases
+*/
+
+// Set things up
+
+var lmdb = require('..');
+var fs = require('fs');
+
+var env = new lmdb.Env();
+env.open({ path: './testdata', mapSize: 16 * 1024 * 1024 });
+
+// Ensure that the database is empty
+var dbi = env.openDbi({
+    name: "test12",
+    create: true
+});
+dbi.drop();
+dbi = env.openDbi({
+    name: "test12",
+    create: true
+});
+
+// See how much we can squeeze into the db
+try {
+    while (true) {
+        for (var i = 0; i < 1000; i++) {
+            var txn = env.beginTxn();
+            txn.putString(dbi, randomString(128), randomString(512));
+            txn.commit();
+        }
+        console.log('database size', getDbSize(), 'MB');
+    }
+}
+catch (error) {
+    console.log('database size', getDbSize(), 'MB');
+    console.log('needs resize');
+}
+
+var info = env.info();
+var stat = env.stat();
+var currentSize = stat.pageSize * (info.lastPageNumber + 1);
+env.resize(currentSize * 2);
+console.log('database size after resize', (currentSize * 2 / 1024 / 1024), 'MB');
+
+for (var i = 0; i < 1000; i++) {
+    var txn = env.beginTxn();
+    txn.putString(dbi, randomString(128), randomString(512));
+    txn.commit();
+}
+console.log('database size', getDbSize(), 'MB');
+
+// Utility functions
+
+function getDbSize () {
+    return fs.statSync('./testdata/data.mdb').size / 1024 / 1024;
+}
+
+function randomString (length) {
+    var result = '';
+    while (length-- > 0) {
+        result += String.fromCharCode(97 + Math.floor(Math.random() * 26));
+    }
+    return result;
+}
+

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -160,6 +160,24 @@ NAN_METHOD(EnvWrap::open) {
     }
 }
 
+NAN_METHOD(EnvWrap::resize) {
+    Nan::HandleScope scope;
+
+    // Get the wrapper
+    EnvWrap *ew = Nan::ObjectWrap::Unwrap<EnvWrap>(info.This());
+
+    if (!ew->env) {
+        return Nan::ThrowError("The environment is already closed.");
+    }
+
+    double mapSizeDouble = info[0]->NumberValue();
+    size_t mapSizeSizeT = (size_t) mapSizeDouble;
+    int rc = mdb_env_set_mapsize(ew->env, mapSizeSizeT);
+    if (rc != 0) {
+        return Nan::ThrowError(mdb_strerror(rc));
+    }
+}
+
 NAN_METHOD(EnvWrap::close) {
     EnvWrap *ew = Nan::ObjectWrap::Unwrap<EnvWrap>(info.This());
     ew->Unref();
@@ -320,6 +338,7 @@ void EnvWrap::setupExports(Handle<Object> exports) {
     envTpl->PrototypeTemplate()->Set(Nan::New<String>("sync").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::sync));
     envTpl->PrototypeTemplate()->Set(Nan::New<String>("stat").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::stat));
     envTpl->PrototypeTemplate()->Set(Nan::New<String>("info").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::info));
+    envTpl->PrototypeTemplate()->Set(Nan::New<String>("resize").ToLocalChecked(), Nan::New<FunctionTemplate>(EnvWrap::resize));
     // TODO: wrap mdb_env_copy too
 
     // TxnWrap: Prepare constructor template

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -148,6 +148,17 @@ public:
     static NAN_METHOD(open);
 
     /*
+        Resizes the maximal size of the memory map. It may be called if no transactions are active in this process.
+        Note that the library does not check for this condition, the caller must ensure it explicitly.
+        (Wrapper for `mdb_env_set_mapsize`)
+
+        Parameters:
+
+        * maximal size of the memory map (the full environment) in bytes (default is 10485760 bytes)
+    */
+    static NAN_METHOD(resize);
+
+    /*
         Closes the database environment.
         (Wrapper for `mdb_env_close`)
     */


### PR DESCRIPTION
LMDB offers the functionality to change the size of the memory map for an environment by calling [mdb_env_set_mapsize](http://www.lmdb.tech/doc/group__internal.html#ga96ac1dd77cc1207915cccb7487d2044f).

Although it is the caller's responsibility to ensure that no transaction is open at this point, it would be good to expose this method.
It allows to resize the memory map in long-lived programs on the fly and on demand.