### PR TITLE
Include -Wimplicit-fallthrough=2 only on gcc >= 7

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,16 @@
       ],
       "conditions": [
         ["OS=='linux'", {
+          "variables": {
+            "gcc_version" : "<!(gcc -dumpversion | cut -d '.' -f 1)",
+          },
+          "conditions": [
+            ["gcc_version>=7", {
+              "cflags": [
+                "-Wimplicit-fallthrough=2",
+              ],
+            }],
+          ],
           "ldflags": [
             "-fPIC",
             "-fvisibility=hidden"


### PR DESCRIPTION
This PR improves the fix that closed issue #121 by including the `-Wimplicit-fallthrough=2` flag when gcc version is at least 7.

It was tested on Ubuntu 17.10 (gcc version 7.2.0) and CentOS 7 (gcc version 4.8.5).