### PR TITLE
Do not close database when emptying it

### DIFF
--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -232,9 +232,12 @@ NAN_METHOD(DbiWrap::drop) {
         }
     }
     
-    dw->isOpen = false;
-    dw->ew->Unref();
-    dw->ew = nullptr;
+    // Only close database if del == 1
+    if (del == 1) {
+        dw->isOpen = false;
+        dw->ew->Unref();
+        dw->ew = nullptr;
+    }
 }
 
 NAN_METHOD(DbiWrap::stat) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,6 +105,16 @@ describe('Node.js LMDB Bindings', function() {
         env.openDbi(1);
       });
     });
+    it('will open a database and empty the database without closing it', function() {
+      var dbi = env.openDbi({
+        name: 'mydb1',
+        create: true
+      });
+      dbi.drop({
+        justFreePages: true
+      });
+      dbi.close();
+    });
     it('will open a database, begin a transaction and get/put/delete string data containing zeros', function() {
       var dbi = env.openDbi({
         name: 'mydb1x',


### PR DESCRIPTION
Currently, the code for closing the database in node-lmdb is always executed in the DBI's `drop` function.
However, it should only be called if the database is deleted+closed and not if it is just emptied.
LMDB Reference: http://www.lmdb.tech/doc/group__mdb.html#gab966fab3840fc54a6571dfb32b00f2db

I also added a test that fails in the previous commit and passes using the modifications.