### PR TITLE
Add compiler variable to binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+      "compiler%": "gcc",
+  },
   "targets": [
     {
       "target_name": "node-lmdb",
@@ -20,7 +23,7 @@
       "conditions": [
         ["OS=='linux'", {
           "variables": {
-            "gcc_version" : "<!(gcc -dumpversion | cut -d '.' -f 1)",
+            "gcc_version" : "<!(<(compiler) -dumpversion | cut -d '.' -f 1)",
           },
           "conditions": [
             ["gcc_version>=7", {

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,6 @@
 {
   "variables": {
-      "compiler%": "gcc",
+      "os_linux_compiler%": "gcc",
   },
   "targets": [
     {
@@ -23,7 +23,7 @@
       "conditions": [
         ["OS=='linux'", {
           "variables": {
-            "gcc_version" : "<!(<(compiler) -dumpversion | cut -d '.' -f 1)",
+            "gcc_version" : "<!(<(os_linux_compiler) -dumpversion | cut -d '.' -f 1)",
           },
           "conditions": [
             ["gcc_version>=7", {


### PR DESCRIPTION
As I had problems using a different compiler for cross compiling (for ARM) I added a compiler variable to the binding. This shouldn't affect the default behavior.
But in case you are able to pass a different compiler.

In my case my gcc version was 7.x and my compiler version for cross compiling was 6.x. That's why I run into problems with the "conditions" for gcc_version >= 7

Best Regards,
Daniel