### PR TITLE
64bit key support with bignums

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -67,6 +67,11 @@ NAN_METHOD(CursorWrap::ctor) {
     if (dw->keyType == NodeLmdbKeyType::Uint32Key && keyType != NodeLmdbKeyType::Uint32Key) {
         return Nan::ThrowError("You specified keyIsUint32 on the Dbi, so you can't use other key types with it.");
     }
+    #if NODE_LMDB_HAS_BIGINT
+    else if (dw->keyType == NodeLmdbKeyType::Uint64Key && keyType != NodeLmdbKeyType::Uint64Key) {
+        return Nan::ThrowError("You specified keyIsUint64 on the Dbi, so you can't use other key types with it.");
+    }
+    #endif
 
     // Open the cursor
     MDB_cursor *cursor;

--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -97,9 +97,15 @@ NAN_METHOD(DbiWrap::ctor) {
             return;
         }
         
+        #if NODE_LMDB_HAS_BIGINT
         if (keyType == NodeLmdbKeyType::Uint32Key) {
             flags |= MDB_INTEGERKEY;
         }
+        #else
+        if (keyType == NodeLmdbKeyType::Uint32Key || keyType == NodeLmdbKeyType::Uint64Key) {
+            flags |= MDB_INTEGERKEY;
+        }
+        #endif
 
         // Set flags for txn used to open database
         Local<Value> create = options->Get(Nan::New<String>("create").ToLocalChecked());

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -33,6 +33,9 @@
 #include <uv.h>
 #include "lmdb.h"
 
+//Bigint added in version 10.4
+#define NODE_LMDB_HAS_BIGINT (NODE_MAJOR_VERSION > 10 || NODE_MAJOR_VERSION == 10 && NODE_MINOR_VERSION >= 4)
+
 using namespace v8;
 using namespace node;
 
@@ -53,6 +56,11 @@ enum class NodeLmdbKeyType {
     // LMDB default key format - Appears to V8 as node::Buffer
     BinaryKey = 3,
 
+#if NODE_LMDB_HAS_BIGINT
+    // LMDB fixed size integer key with 32 bit keys - Appearts to V8 as a Bigint which 
+    // is then attempted to be interpreted as aUint64
+    Uint64Key = 4,
+#endif
 };
 
 // Exports misc stuff to the module
@@ -192,6 +200,7 @@ public:
         * name: the name of the database (or null to use the unnamed database)
         * create: if true, the database will be created if it doesn't exist
         * keyIsUint32: if true, keys are treated as 32-bit unsigned integers
+        * keyIsUint64: (only in node 10.4.0 or later) if true, keys are treated as 64-bit unsigned integers
         * dupSort: if true, the database can hold multiple items with the same key
         * reverseKey: keys are strings to be compared in reverse order
         * dupFixed: if dupSort is true, indicates that the data items are all the same size


### PR DESCRIPTION
As discussed in #111. I didn't implement defaulting bigints to buffers since there's no easy v8 api to transform a bigint into an array of bytes. I'm guessing v8 doesn't expose such an API to avoid making an opinionated choice on how to store signed numbers in binary format (the logical options being either twos compliment or signbit+unsignedbytes.) 

With that in mind I think the correct approach is to allow users to choose how they want to serialize bigints. The obvious easy answer it to use the toString() method at the cost of some extra memory and ordering, or to store the data as a binary key by doing Buffer.from(1n.toString(16),'hex') if they are unsigned bigints, and coming up with a sign-ness encoding/decoding if they are signed.