### PR TITLE
Update lmdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,9 +377,9 @@ git remote add lmdb https://github.com/LMDB/lmdb.git
 # Fetch new remote
 git fetch lmdb
 # Adding the subtree (when it's not there yet)
-git subtree add  --prefix=dependencies/lmdb lmdb HEAD --squash
+git subtree add  --prefix=dependencies/lmdb lmdb mdb.RE/0.9 --squash
 # Updating the subtree (when already added)
-git subtree pull --prefix=dependencies/lmdb lmdb HEAD --squash
+git subtree pull --prefix=dependencies/lmdb lmdb mdb.RE/0.9 --squash
 ```
 
 ### Developer FAQ

--- a/dependencies/lmdb/libraries/liblmdb/CHANGES
+++ b/dependencies/lmdb/libraries/liblmdb/CHANGES
@@ -2,6 +2,7 @@ LMDB 0.9 Change Log
 
 LMDB 0.9.24 Engineering
 	ITS#8969 Tweak mdb_page_split
+	ITS#8975 WIN32 fix writemap set_mapsize crash
 
 LMDB 0.9.23 Release (2018/12/19)
 	ITS#8756 Fix loose pages in dirty list

--- a/dependencies/lmdb/libraries/liblmdb/CHANGES
+++ b/dependencies/lmdb/libraries/liblmdb/CHANGES
@@ -3,6 +3,7 @@ LMDB 0.9 Change Log
 LMDB 0.9.24 Engineering
 	ITS#8969 Tweak mdb_page_split
 	ITS#8975 WIN32 fix writemap set_mapsize crash
+	ITS#9007 Fix loose pages in WRITEMAP
 
 LMDB 0.9.23 Release (2018/12/19)
 	ITS#8756 Fix loose pages in dirty list

--- a/dependencies/lmdb/libraries/liblmdb/mdb.c
+++ b/dependencies/lmdb/libraries/liblmdb/mdb.c
@@ -3991,9 +3991,9 @@ mdb_env_map(MDB_env *env, void *addr)
 		 * and won't map more than the file size.
 		 * Just set the maxsize right now.
 		 */
-		if (SetFilePointer(env->me_fd, sizelo, &sizehi, 0) != (DWORD)sizelo
+		if (!(flags & MDB_WRITEMAP) && (SetFilePointer(env->me_fd, sizelo, &sizehi, 0) != (DWORD)sizelo
 			|| !SetEndOfFile(env->me_fd)
-			|| SetFilePointer(env->me_fd, 0, NULL, 0) != 0)
+			|| SetFilePointer(env->me_fd, 0, NULL, 0) != 0))
 			return ErrCode();
 	}
 

--- a/dependencies/lmdb/libraries/liblmdb/mdb.c
+++ b/dependencies/lmdb/libraries/liblmdb/mdb.c
@@ -3109,9 +3109,9 @@ mdb_freelist_save(MDB_txn *txn)
 			} else {
 				x = mdb_mid2l_search(dl, mp->mp_pgno);
 				mdb_tassert(txn, dl[x].mid == mp->mp_pgno);
+				mdb_dpage_free(env, mp);
 			}
 			dl[x].mptr = NULL;
-			mdb_dpage_free(env, mp);
 		}
 		{
 			/* squash freed slots out of the dirty list */


### PR DESCRIPTION
This is just an minor incremental update of the LMDB dependency, but it happens to fix an important stability issue for windows with writemaps.