### PR TITLE
Add prebuild deps, scripts, and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Build and test data
 build
+prebuilds
 testdata
 test/testdata
 benchmark/benchdata
@@ -41,3 +42,4 @@ node_modules/
 # Visual Studio Code directory
 .vscode
 
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -30,12 +30,15 @@
   "version": "0.6.2",
   "main": "./index.js",
   "scripts": {
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuild": "prebuild --all --verbose",
     "test": "./node_modules/.bin/mocha test/**.test.js --recursive",
     "benchmark": "node ./benchmark/index.js"
   },
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.2.1",
+    "prebuild-install": "^5.2.5",
     "nan": "^2.12.0"
   },
   "devDependencies": {
@@ -44,6 +47,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "node-gyp": "^3.6.0",
+    "prebuild": "8.2.1",
     "rimraf": "^2.6.1",
     "jshint": "^2.9.4"
   }


### PR DESCRIPTION
This adds the prebuild dependencies, scripts, and .gitignore addition for #147 (only the prebuild-install is really necessary for users, actually easiest to globally install `npm install -g prebuild` for yourself, I think). You will have to run prebuild locally for new versions, and upload with a github token (instructions at https://www.npmjs.com/package/prebuild). I think you can only generate prebuilds for your architecture, so not sure if you want others to upload other binaries (I am running win32x64, which is what I was interested in creating binaries for), although unfortunately I think github tokens don't provide much granularity with permissions.
