### PR TITLE
Add detachBuffer method for detaching buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Advanced examples:
 
 #### Unsafe Get Methods
 Because of the nature of LMDB, the data returned by `txn.getStringUnsafe()`, `txn.getBinaryUnsafe()`, `cursor.getCurrentStringUnsafe()`
-and `cursor.getCurrentBinaryUnsafe()` is **only valid until the next `put` operation or the end of the transaction**.
+and `cursor.getCurrentBinaryUnsafe()` is **only valid until the next `put` operation or the end of the transaction**. Also, with Node 14+, you must detach the buffer after using it, by calling `env.detachBuffer(buffer)`. This must be done before accessing the same entry again (or V8 will crash).
 If you need to use the data *later*, you can use the `txn.getBinary()`, `txn.getString()`, `cursor.getCurrentBinary()` and
 `cursor.getCurrentString()` methods. For most usage, the optimisation (no copy) gain from using the unsafe methods is so small
 as to be negligible - the `Unsafe` methods should be avoided.

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -438,6 +438,13 @@ NAN_METHOD(EnvWrap::info) {
     info.GetReturnValue().Set(obj);
 }
 
+NAN_METHOD(EnvWrap::detachBuffer) {
+    Nan::HandleScope scope;
+    #if NODE_VERSION_AT_LEAST(12,0,0)
+    Local<v8::ArrayBuffer>::Cast(info[0])->Detach();
+    #endif
+}
+
 NAN_METHOD(EnvWrap::beginTxn) {
     Nan::HandleScope scope;
 
@@ -653,6 +660,7 @@ void EnvWrap::setupExports(Local<Object> exports) {
     envTpl->PrototypeTemplate()->Set(isolate, "stat", Nan::New<FunctionTemplate>(EnvWrap::stat));
     envTpl->PrototypeTemplate()->Set(isolate, "info", Nan::New<FunctionTemplate>(EnvWrap::info));
     envTpl->PrototypeTemplate()->Set(isolate, "resize", Nan::New<FunctionTemplate>(EnvWrap::resize));
+    envTpl->PrototypeTemplate()->Set(isolate, "detachBuffer", Nan::New<FunctionTemplate>(EnvWrap::detachBuffer));
     // TODO: wrap mdb_env_copy too
 
     // TxnWrap: Prepare constructor template

--- a/src/node-lmdb.h
+++ b/src/node-lmdb.h
@@ -128,6 +128,11 @@ public:
     static NAN_METHOD(stat);
     
     /*
+        Detaches a buffer from the backing store
+    */
+    static NAN_METHOD(detachBuffer);
+
+    /*
         Gets information about the database environment.
     */
     static NAN_METHOD(info);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -340,7 +340,12 @@ describe('Node.js LMDB Bindings', function() {
       var buffer = new Buffer('48656c6c6f2c20776f726c6421', 'hex');
       txn.putBinary(dbi, 'key2', buffer);
       var data = txn.getBinaryUnsafe(dbi, 'key2');
+      var byte = data[0]; // make sure we can access it
+      env.detachBuffer(data.buffer);
+      var data = txn.getBinaryUnsafe(dbi, 'key2');
+      var byte = data[0]; // make sure we can access it
       data.should.deep.equal(buffer);
+      env.detachBuffer(data.buffer);
       txn.del(dbi, 'key2');
       var data2 = txn.getBinaryUnsafe(dbi, 'key2');
       should.equal(data2, null);


### PR DESCRIPTION
This a minimal addition to support Node v14's new backing store buffer memory model, and adds a detachBuffer  to make it feasible to deterministically use buffers from shared/memory-mapped (get*Unsafe methods) in Node v14, fixes #163